### PR TITLE
Remove bold from headings

### DIFF
--- a/less/style.less
+++ b/less/style.less
@@ -31,6 +31,18 @@ a, a:hover, a:visited, a:link {
   }
 }
 
+h2 {
+    margin-bottom: 0px;
+    margin-top: 2em;
+    font-weight: normal;
+}
+
+h3 {
+    color: #c9851d;
+    font-size: 3em;
+    font-weight: normal;
+}
+
 #page-body {
 }
 


### PR DESCRIPTION
By lightening the weight of the headings and increasing the spacing, many pages are dramatically improved in readability in my opinion. Especially pages like the change list.
