### PR TITLE
Missing icon for not-built in-progress

### DIFF
--- a/less/images.less
+++ b/less/images.less
@@ -47,7 +47,7 @@
   .icon-img('../images/ic_autorenew_black.svg', @color-red);
 }
 
-.icon-grey-anime {
+.icon-grey-anime, .icon-nobuilt-anime {
   .icon-img('../images/ic_autorenew_black.svg', @color-grey);
 }
 
@@ -58,7 +58,8 @@
 .icon-blue-anime,
 .icon-red-anime,
 .icon-grey-anime,
-.icon-yellow-anime {
+.icon-yellow-anime,
+.icon-nobuilt-anime {
   -webkit-animation: rotating 2s linear infinite;
   animation: rotating 2s linear infinite;
 }


### PR DESCRIPTION
When you run a build that hasn't been built before, the icon is missing.
